### PR TITLE
Update eclipse-orbit.jsonnet

### DIFF
--- a/otterdog/eclipse-orbit.jsonnet
+++ b/otterdog/eclipse-orbit.jsonnet
@@ -6,7 +6,7 @@ orgs.newOrg('eclipse-orbit') {
     default_repository_permission: "none",
     dependabot_security_updates_enabled_for_new_repositories: false,
     description: "Provides infrastructure for redistributing third-party libraries as OSGi bundles via p2 repositories.",
-    discussion_source_repository: "eclipse-orbit/orbit",
+    discussion_source_repository: "eclipse-orbit/orbit-simrel",
     email: "orbit-dev@eclipse.org",
     has_discussions: true,
     name: "Eclipse Orbit",


### PR DESCRIPTION
Given that eclipse-orbit/orbit is archived, I think we need to make eclipse-orbit/orbit-simrel the organization's discussion_source_repository.